### PR TITLE
Paths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/andromeda-light"]
 	path = themes/andromeda-light
-	url = https://github.com/gethugothemes/andromeda-light
+	url = https://github.com/twiinIT/andromeda-light-hugo

--- a/content/portfolio/2023/pyturbo/index.md
+++ b/content/portfolio/2023/pyturbo/index.md
@@ -5,7 +5,7 @@ subtitle: "Turbofan design made Open-Source"
 draft: false
 image: "/images/portfolio/pyturbo_icon.gif"
 weight: 1
-article_url: "./2023/pyturbo"
+article_url: "/portfolio/2023/pyturbo"
 ---
 
 ### Objectives
@@ -13,29 +13,28 @@ article_url: "./2023/pyturbo"
 - Demonstrate modeling and design capabilities based on CoSApp.
 - Provide a turbofan Open-Source library for training and as a base block of advanced simulations workflows.
 
-
 ### Current status
 
 - A turbofan (2 shafts) architecture is covered from single physics/components to the full product, using modular intermediate assemblies.
 - Multiple off-design and design strategies are available as numerical workflows.
 
+### Outlook
+
+- Add alternative modelings, architectures.
+- Improve the learning experience with beginner to advanced tutorials.
+
 <div class='row'>
 <div class='col-lg-5 col-md-5 col-12' text-align='center'>
     <div class='imgbox'>
-        {{<figure src=pyturbo_icon.gif width="100%" class="center-fit">}}
+        {{<figure src=/portfolio/2023/pyturbo/pyturbo_icon.gif width="100%" class="center-fit">}}
     </div>
     <center><p> Turbofan engine being scaled by the user in real time.</p></center>
 </div>
 <div class='col-lg-7 col-md-7 col-12' text-align='center'>
     <div class='imgbox'>
-        {{<figure src=pyturbo_aircraft.png width="100%">}}
+        {{<figure src=/portfolio/2023/pyturbo/pyturbo_aircraft.png width="100%">}}
     </div>
     <center><p> Aircraft digital twin mounted with 2 turbofans.</p></center>
 </div>
 </div>
 </div>
-
-### Outlook
-
-- Add alternative modelings, architectures.
-- Improve the learning experience with beginner to advanced tutorials.

--- a/content/portfolio/2023/pyturbo/index.md
+++ b/content/portfolio/2023/pyturbo/index.md
@@ -26,13 +26,13 @@ article_url: "/portfolio/2023/pyturbo"
 <div class='row'>
 <div class='col-lg-5 col-md-5 col-12' text-align='center'>
     <div class='imgbox'>
-        {{<figure src=/portfolio/2023/pyturbo/pyturbo_icon.gif width="100%" class="center-fit">}}
+        {{<figure src=/images/portfolio/pyturbo_icon.gif width="100%" class="center-fit">}}
     </div>
     <center><p> Turbofan engine being scaled by the user in real time.</p></center>
 </div>
 <div class='col-lg-7 col-md-7 col-12' text-align='center'>
     <div class='imgbox'>
-        {{<figure src=/portfolio/2023/pyturbo/pyturbo_aircraft.png width="100%">}}
+        {{<figure src=/images/portfolio/pyturbo_aircraft.png width="100%">}}
     </div>
     <center><p> Aircraft digital twin mounted with 2 turbofans.</p></center>
 </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,58 +1,5 @@
 {{define "main"}}
 
-{{if site.Params.buy_premium_popup}}
-<div class="buy-premium position-fixed fade">
-  <div class="block p-4 p-lg-5 bg-white rounded-lg shadow-lg call-to-action has-bg-color">
-    <div class="position-relative" style="z-index: 2;">
-      <h2 class="text-center mb-4">Get Andromeda Premium</h2>
-      <div class="row">
-        <div class="col-sm-6">
-          <p class="mb-1 font-weight-bold text-dark">Premium page list:</p>
-          <ol class="pl-0">
-            <li>How It Works</li>
-            <li>Pricing</li>
-            <li>Author Single</li>
-            <li>Career</li>
-            <li>Job Details</li>
-            <li>Case Studies</li>
-            <li>Case Studies Details</li>
-            <li>Changlog</li>
-            <li>Signin</li>
-            <li>Signup</li>
-          </ol>
-        </div>
-        <div class="col-sm-6">
-          <p class="mb-1 font-weight-bold text-dark">Premium Features list:</p>
-          <ol class="pl-0">
-            <li>Multiple author and single author</li>
-            <li>Multiple language support (Fr, En)</li>
-            <li>Forestry cms pre-configured</li>
-            <li>Caching enable</li>
-          </ol>
-        </div>
-      </div>
-      <div class="text-center">
-        <a href="https://gethugothemes.com/products/andromeda/" class="btn btn-primary mt-2">Download Now</a>
-      </div>
-    </div>
-    <button type="button" class="close" aria-label="Close">
-      <span aria-hidden="true">&times;</span>
-    </button>
-
-    <div class="has-circle has-bg-anim" style="opacity: .5">
-      <img class="wave-1 w-100" src="{{`images/waves/05.svg` | absURL}}" alt="*">
-      <span class="circle-1 ratio-32"></span>
-      <span class="circle-2 ratio-37"></span>
-      <span class="circle-3 ratio-47"></span>
-      <span class="circle-4 ratio-20"></span>
-      <span class="circle-5 ratio-73"></span>
-      <span class="circle-6 ratio-37"></span>
-    </div>
-  </div>
-  <div class="overlay"></div>
-</div>
-{{end}}
-
 {{with .Params.banner}}
 <section class="banner">
   <div class="container-xxl">


### PR DESCRIPTION
- Using absolute paths in portfolio posts.
- Changed the theme submodule repo to the twiinIT fork.

Obs: the twiinIT fork was reset to a previous commit that was actually pointed to when the theme was first installed. The modifications in the last version of andromeda-light seemed to require partial scripts that were not there, hence the favicon error then updated manually. 

It was tested with the newest version of hugo v0.135.0.